### PR TITLE
Bugfix: Show spinner and disable tag input when saving tags

### DIFF
--- a/src/components/TagsInput.js
+++ b/src/components/TagsInput.js
@@ -42,13 +42,14 @@ const renderInput = (props) => {
 const handleValidate = (tag) => tag.length <= 18
 
 const CustomTagsInput = React.forwardRef(
-  ({ tags, handleOnChange, handleRemoveTag, setShowError }, ref) => {
+  ({ tags, disabled, handleOnChange, handleRemoveTag, setShowError }, ref) => {
     return (
       <TagsInput
         value={tags}
         onChange={handleOnChange}
         addOnBlur
         onlyUnique
+        disabled={disabled}
         maxTags={10}
         preventSubmit={false}
         validate={handleValidate}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -2,6 +2,7 @@ export { default as NavLink } from './shared/NavLink'
 export { default as NavLinkIcon } from './shared/NavLinkIcon'
 export { default as SEO } from './shared/SEO'
 export { default as SyncButton } from './shared/SyncButton'
+export { default as KbdKey } from './shared/KbdKey'
 
 export { default as Layout } from './Layout'
 export { default as Thing } from './Thing'

--- a/src/components/shared/KbdKey.js
+++ b/src/components/shared/KbdKey.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Tag } from '@chakra-ui/core'
+
+/**
+ * Styled `<kbd />` element. Composed using Chakra UI's `<Tag />` component with
+ * some additional styling.
+ * @param {String} props.text Text representing a keyboard key.
+ */
+const KbdKey = ({ text }) => (
+  <Tag mx={1} size='sm' borderWidth='1px' borderColor='gray.400'>
+    {text}
+  </Tag>
+)
+
+KbdKey.propTypes = {
+  /** string representing a keyboard key, e.g. "Enter" or "Ctrl" */
+  text: PropTypes.string.isRequired,
+}
+
+export default KbdKey

--- a/src/contexts/TagModalContext.js
+++ b/src/contexts/TagModalContext.js
@@ -1,7 +1,14 @@
 import React, { createContext, useState, useContext } from 'react'
 import {
   Stack,
+  Box,
+  Text,
   Button,
+  CloseButton,
+  Alert,
+  AlertIcon,
+  AlertTitle,
+  AlertDescription,
   Modal,
   ModalOverlay,
   ModalContent,
@@ -11,15 +18,9 @@ import {
   ModalCloseButton,
   useDisclosure,
 } from '@chakra-ui/core'
-import {
-  CloseButton,
-  Alert,
-  AlertIcon,
-  AlertTitle,
-  AlertDescription,
-} from '@chakra-ui/core'
+import { RiLightbulbLine } from 'react-icons/ri'
 
-import { CustomTagsInput } from '../components'
+import { CustomTagsInput, KbdKey } from '../components'
 
 import config from '../config'
 import { useAuth } from './AuthContext'
@@ -52,6 +53,7 @@ const TagValidationErrorAlert = ({ setShowError }) => {
 const TagModalProvider = ({ children }) => {
   const [thing, setThing] = useState({})
   const [tags, setTags] = useState([])
+  const [isLoading, setIsLoading] = useState(false)
   const [showError, setShowError] = useState(false)
   const { token } = useAuth()
   const { things, updateThings } = useThings()
@@ -76,6 +78,7 @@ const TagModalProvider = ({ children }) => {
   }
 
   const handleSubmit = async () => {
+    setIsLoading(true)
     const updatedThing = { ...thing, tags: [...tags] }
     await setThing(updatedThing)
     await updateThings(
@@ -95,6 +98,7 @@ const TagModalProvider = ({ children }) => {
       },
     })
     await updateFilters()
+    setIsLoading(false)
     onClose()
   }
 
@@ -123,6 +127,7 @@ const TagModalProvider = ({ children }) => {
               <CustomTagsInput
                 ref={initialRef}
                 tags={tags}
+                disabled={isLoading}
                 handleOnChange={handleOnChange}
                 handleRemoveTag={handleRemoveTag}
                 setShowError={setShowError}
@@ -131,10 +136,30 @@ const TagModalProvider = ({ children }) => {
                 ml={2}
                 size='md'
                 minW='max-content'
+                isLoading={isLoading}
                 onClick={handleSubmit}
               >
                 Save
               </Button>
+            </Stack>
+            <Stack mt={4} isInline fontSize='sm'>
+              <Box d='flex' alignItems='center'>
+                <Box
+                  d='flex'
+                  justifyContent='space-between'
+                  alignItems='center'
+                >
+                  <Box as={RiLightbulbLine} />
+                  <Text fontWeight='bold'>ProTip!</Text>
+                </Box>
+              </Box>
+              <Box>
+                Use the
+                <KbdKey text='Enter' />
+                or
+                <KbdKey text='Tab' />
+                keys to add multiple tags, then click "Save" to submit.
+              </Box>
             </Stack>
           </ModalBody>
 
@@ -142,9 +167,6 @@ const TagModalProvider = ({ children }) => {
             {showError && (
               <TagValidationErrorAlert setShowError={setShowError} />
             )}
-            {/* <Button variantColor='blue' mr={3} onClick={onClose}>
-              Close
-            </Button> */}
           </ModalFooter>
         </ModalContent>
       </Modal>


### PR DESCRIPTION
Fixes #11. Minor improvement to the UX wherein saving tags displays a saving indicator and the tag input field becomes disabled. This is to prevent users from trying to add more tags when the update tags API request is already in-flight.

A hint/tip message was also added to teach users that multiple tags can be added before needing to save.